### PR TITLE
Type cast boolean values in BaseModel

### DIFF
--- a/app/models/BaseModel.php
+++ b/app/models/BaseModel.php
@@ -365,6 +365,11 @@ abstract class BaseModel extends \CModel
 				// Handle special case attribute types
 				switch ($config['type'])
 				{
+					case AttributeType::Bool:
+					{
+						$value = (bool) $value;
+						break;
+					}
 					case AttributeType::DateTime:
 					{
 						if ($value)


### PR DESCRIPTION
Booleans from the database show up as integers. Values from form submissions show up as empty strings for false. This will cast them all to PHP booleans so accurate comparisons can be made in save hooks.
