### PR TITLE
Forcibly hide the view mode buttons when the action triggers are hidden.

### DIFF
--- a/app/resources/js/craft.js
+++ b/app/resources/js/craft.js
@@ -2267,6 +2267,12 @@ Craft.BaseElementIndex = Garnish.Base.extend(
 
 		this.$toolbarTableRow.children().not(this.$selectAllContainer).removeClass('hidden');
 
+		// Check if there are any view mode buttons and force hide if not
+		if (!this.$viewModeBtnTd.find('.btngroup').children().length)
+		{
+			this.$viewModeBtnTd.addClass('hidden');
+		}
+
 		this.showingActionTriggers = false;
 	},
 


### PR DESCRIPTION
This is to counteract the visual issue of having an un-hidden `<td>` in the toolbar.

![broken-toolbar](https://cloud.githubusercontent.com/assets/404219/8745321/9d828e04-2c76-11e5-9a99-201867d3d996.png)
