### PR TITLE
Fixes cookie validation with custom validationKey

### DIFF
--- a/app/etc/web/WebApp.php
+++ b/app/etc/web/WebApp.php
@@ -118,6 +118,7 @@ class WebApp extends \CWebApplication
 		if ($validationKey = $this->config->get('validationKey'))
 		{
 			$this->security->setValidationKey($validationKey);
+			$this->getComponent('securityManager')->setValidationKey($validationKey);
 		}
 
 		// Attach our own custom Logger


### PR DESCRIPTION
When a custom `validationKey` is used, then it is assigned to the "security" component (instance of `Craft\SecurityService`) during the web app boostrap in `Craft\WebApp::init`. However, it is not assigned to the "securityManager" component (instance of `CSecurityManager`), which is initialized by the Yii bootrap.

Now when setting a cookie using `UserSessionService::saveCookie` the "security" component is used. Later on, when the cookies are actually written using `CHttpRequest::addCookie`, the "securityManager" component is used to sign the cookie, which does not have the custom `validationKey` assigned and therefore uses a random one (which is then stored in global state).

Later on in `Craft::getCookies`, which overloads `CCookieCollection::getCookies`, the "security" component is used to validate the signed data of the cookie, which it cannot, since it was signed by the random validation key of "securityManager".
