### PR TITLE
Translates entry field names in CP table view

### DIFF
--- a/app/templates/_elements/tableview/container.html
+++ b/app/templates/_elements/tableview/container.html
@@ -8,9 +8,9 @@
 				{% for attribute in attributes %}
 					{% set icon = (attribute[1].icon is defined ? attribute[1].icon : null) %}
 					<th scope="col" data-attribute="{{ attribute[0] }}"
-						{%- if icon %} data-icon="{{ icon }}" title="{{ attribute[1].label }}"{% endif %}
+						{%- if icon %} data-icon="{{ icon }}" title="{{ attribute[1].label|t }}"{% endif %}
 					>
-						{%- if not icon %}{{ attribute[1].label }}{% endif -%}
+						{%- if not icon %}{{ attribute[1].label|t }}{% endif -%}
 					</th>
 				{% endfor %}
 			</tr>


### PR DESCRIPTION
The table view did not use translated labels - I have translations for my field names being displayed correctly on the edit form page for an entry, while the table view ignored them.
