### PR TITLE
Fixing SQL query for deleteLayoutById when layoutId is array with empty values

### DIFF
--- a/app/services/FieldsService.php
+++ b/app/services/FieldsService.php
@@ -986,6 +986,10 @@ class FieldsService extends BaseApplicationComponent
 
 		if (is_array($layoutId))
 		{
+			$layoutId = array_filter($layoutId);
+ 			if (empty($layoutId)) {
+ 				return false;
+ 			}
 			$affectedRows = craft()->db->createCommand()->delete('fieldlayouts', array('in', 'id', $layoutId));
 		}
 		else


### PR DESCRIPTION
When `$layoutId` for some reason is an array with empty values, an SQL exception is thrown. Example array:

```
$layoutId = [
    0 => '',
];
```

To prevent this, run array_filter if `$layoutId` is an array.