### PR TITLE
Update Imagick.php

### DIFF
--- a/app/vendor/imagine/imagine/lib/Imagine/Imagick/Imagick.php
+++ b/app/vendor/imagine/imagine/lib/Imagine/Imagick/Imagick.php
@@ -48,6 +48,9 @@ class Imagick extends \Imagick {
         $this->setOption('png:compression-strategy', '1');
         $this->setOption('png:exclude-chunk', 'all');
         $this->setInterlaceScheme(\Imagick::INTERLACE_NO);
+        
+        // Prevent memory leak
+	    $this->setResourceLimit(\Imagick::RESOURCETYPE_MEMORY, 256);
 
         // Older Imagick versions might not have this. Better make sure.
         if (!$preserveColorInfo &&  method_exists($this, 'transformimagecolorspace'))


### PR DESCRIPTION
When resizing a lot of images, the memory consumption will keep growing and eventually the system will run out of memory.
This limits the resizing to use 256mb of system memory